### PR TITLE
Fix RemoveRandomInstance mutation

### DIFF
--- a/models/ttc2019.live.mutator/src/ttc2019/live/mutator/ops/RemoveRandomInstance.java
+++ b/models/ttc2019.live.mutator/src/ttc2019/live/mutator/ops/RemoveRandomInstance.java
@@ -35,9 +35,9 @@ public class RemoveRandomInstance extends AbstractMutationOperator {
 		}
 		final EObject target = oTarget.get();
 
-		final String uriFragment = target.eResource().getURIFragment(target);
 		final EObject eContainer = target.eContainer();
 		final EReference feature = (EReference) target.eContainingFeature();
+		final String uriFragment = eContainer.eResource().getURIFragment(eContainer);
 
 		// Apply the change
 		int idxTarget = 0;


### PR DESCRIPTION
In RemoveRandomInstance, the URI fragment used to refer affected element
wrongly refers to the deleted element instead of its container.

For instance, in [random10-single-1/applied.changes](https://github.com/TheoLeCalvar/ttc2019-live/blob/master/models/random10/random10-single-1/applied.changes#L4) the URI refers to the Para that should be removed and not the Section containing it.

This commit is based on the behavior of the `CompositionListDeletion.apply` method from ttc2018 live contest.
Original file [here](https://github.com/TransformationToolContest/ttc2018liveContest/blob/master/solutions/EMFSolutionTemplate/src/Changes/impl/CompositionListDeletionImpl.java#L227). 